### PR TITLE
Add "const" to localSocketPath

### DIFF
--- a/CO_epoll_interface.c
+++ b/CO_epoll_interface.c
@@ -396,7 +396,7 @@ CO_ReturnError_t CO_epoll_createGtw(CO_epoll_gtw_t *epGtw,
                                     int epoll_fd,
                                     int32_t commandInterface,
                                     uint32_t socketTimeout_ms,
-                                    char *localSocketPath)
+                                    const char *localSocketPath)
 {
     int ret;
     struct epoll_event ev = {0};

--- a/CO_epoll_interface.h
+++ b/CO_epoll_interface.h
@@ -237,7 +237,7 @@ typedef struct {
     /** Socket timeout timer in microseconds */
     uint32_t socketTimeoutTmr_us;
     /** Path in case of local socket */
-    char *localSocketPath;
+    const char *localSocketPath;
     /** Gateway socket file descriptor */
     int gtwa_fdSocket;
     /** Gateway io stream file descriptor */
@@ -265,7 +265,7 @@ CO_ReturnError_t CO_epoll_createGtw(CO_epoll_gtw_t *epGtw,
                                     int epoll_fd,
                                     int32_t commandInterface,
                                     uint32_t socketTimeout_ms,
-                                    char *localSocketPath);
+                                    const char *localSocketPath);
 
 /**
  * Close gateway-ascii sockets


### PR DESCRIPTION
CO_epoll_createGtw needlessly requires localSocketPath to be mutable.
This particularly matters when linking with C++ codes.