### PR TITLE
Add missing #ifndef checks

### DIFF
--- a/CO_driver_target.h
+++ b/CO_driver_target.h
@@ -102,11 +102,15 @@ extern "C" {
      | CO_CONFIG_GLOBAL_FLAG_CALLBACK_PRE)
 #endif
 
+#ifndef CO_CONFIG_GFC
 #define CO_CONFIG_GFC (CO_CONFIG_GFC_ENABLE | CO_CONFIG_GFC_CONSUMER | CO_CONFIG_GFC_PRODUCER)
+#endif
 
+#ifndef CO_CONFIG_SRDO
 #define CO_CONFIG_SRDO                                                                                                 \
     (CO_CONFIG_SRDO_ENABLE | CO_CONFIG_SRDO_CHECK_TX | CO_CONFIG_GLOBAL_FLAG_CALLBACK_PRE                              \
      | CO_CONFIG_GLOBAL_FLAG_TIMERNEXT)
+#endif
 
 #ifndef CO_CONFIG_GTW
 #define CO_CONFIG_GTW                                                                                                  \


### PR DESCRIPTION
Commit 2854ea4a introduced "#define CO_CONFIG_GFC ..." and "#define CO_CONFIG_SRDO ..." without surrounding it around #ifndef.

As a result, when e.g. CO_CONFIG_GFC or CO_CONFIG_SRDO is defined in a Makefile, the compiler will complain about redefining that variable.